### PR TITLE
Fix next pickup date when on the same day

### DIFF
--- a/aiorecollect/client.py
+++ b/aiorecollect/client.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from aiohttp import ClientSession, ClientTimeout
 from aiohttp.client_exceptions import ClientError
 
-from aiorecollect.errors import RequestError
+from aiorecollect.errors import DataError, RequestError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,8 +72,10 @@ class Client:
     async def async_get_next_pickup_event(self) -> PickupEvent:
         """Get the very next pickup event."""
         pickup_events = await self.async_get_pickup_events()
-        future_events = [event for event in pickup_events if event.date > date.today()]
-        return future_events[0]
+        for event in pickup_events:
+            if event.date > date.today():
+                return event
+        raise DataError("No pickup events found after today")
 
     async def async_get_pickup_events(
         self, *, start_date: Optional[date] = None, end_date: Optional[date] = None

--- a/aiorecollect/errors.py
+++ b/aiorecollect/errors.py
@@ -11,3 +11,9 @@ class RequestError(RecollectError):
     """Define a exception related to HTTP request errors."""
 
     pass
+
+
+class DataError(RecollectError):
+    """Define an exception related to invalid/missing data."""
+
+    pass


### PR DESCRIPTION
**Describe what the PR does:**

Previously, `Client.async_get_next_pickup_event()` would always return the next pickup event _except_ on the day of a pickup; in that case, `Client.async_get_next_pickup_event()` would return the current day. We always want to return the next date, so this PR ensures that we always pick the next possible date after today.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
