### PR TITLE
Alter how the next pickup event is calculated

### DIFF
--- a/aiorecollect/client.py
+++ b/aiorecollect/client.py
@@ -72,7 +72,7 @@ class Client:
         """Get the very next pickup event."""
         pickup_events = await self.async_get_pickup_events()
         for event in pickup_events:
-            if event.date > date.today():
+            if event.date >= date.today():
                 return event
         raise DataError("No pickup events found after today")
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -107,8 +107,8 @@ async def test_get_next_pickup_event_same_day(aresponses):
         client = Client(TEST_PLACE_ID, TEST_SERVICE_ID, session=session)
         next_pickup_event = await client.async_get_next_pickup_event()
 
-        assert next_pickup_event.date == date(2020, 11, 9)
-        assert next_pickup_event.pickup_types == ["garbage", "organics"]
+        assert next_pickup_event.date == date(2020, 11, 2)
+        assert next_pickup_event.pickup_types == ["garbage", "recycle", "organics"]
         assert next_pickup_event.area_name == "Atlantis"
 
 


### PR DESCRIPTION
**Describe what the PR does:**

It turns out that Recollect can return data that ends on the current pickup date. This PR alters the `client.async_get_next_pickup_event` to return that event, rather than raising an exception.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
