### PR TITLE
Alter pickup type representation to include optional friendly name

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,16 @@ The `PickupEvent` object that is returned from the above calls comes with three
 properties:
 
 * `date`: a `datetime.date` that denotes the pickup date
-* `pickup_types`: a list of pickup types that will occur in this event
+* `pickup_types`: a list of `PickupType` objects that will occur with this event
 * `area_name`: the name of the area in which the event is occurring
+
+## The `PickupType` Object
+
+The `PickupType` object contains the "internal" name of the pickup type _and_ a
+human-friendly representation when it exists:
+
+* `name`: the internal name of the pickup type
+* `friendly_name`: the humany-friendly name of the pickup type (if it exists)
 
 ## Connection Pooling
 

--- a/tests/fixtures/pickup_data_response.json
+++ b/tests/fixtures/pickup_data_response.json
@@ -441,6 +441,20 @@
       "is_approved": 1,
       "custom_subject": "",
       "zone_id": 1854
+    },
+    {
+      "opts": {
+        "calendar_only": 0
+      },
+      "day": "2020-11-30",
+      "id": 5770965,
+      "options": {
+        "ending_at": "2020-12-31"
+      },
+      "custom_message": "",
+      "is_approved": 1,
+      "custom_subject": "",
+      "zone_id": 1854
     }
   ],
   "zones": {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,7 +5,7 @@ from aiohttp import ClientSession
 from freezegun import freeze_time
 import pytest
 
-from aiorecollect import Client
+from aiorecollect.client import Client, PickupType
 from aiorecollect.errors import DataError, RequestError
 
 from tests.common import TEST_PLACE_ID, TEST_SERVICE_ID, load_fixture
@@ -40,7 +40,11 @@ async def test_get_next_pickup_event(aresponses):
         next_pickup_event = await client.async_get_next_pickup_event()
 
         assert next_pickup_event.date == date(2020, 11, 2)
-        assert next_pickup_event.pickup_types == ["garbage", "recycle", "organics"]
+        assert next_pickup_event.pickup_types == [
+            PickupType("garbage", "Trash"),
+            PickupType("recycle"),
+            PickupType("organics"),
+        ]
         assert next_pickup_event.area_name == "Atlantis"
 
 
@@ -63,7 +67,11 @@ async def test_get_next_pickup_event_oneshot(aresponses):
     next_pickup_event = await client.async_get_next_pickup_event()
 
     assert next_pickup_event.date == date(2020, 11, 2)
-    assert next_pickup_event.pickup_types == ["garbage", "recycle", "organics"]
+    assert next_pickup_event.pickup_types == [
+        PickupType("garbage", "Trash"),
+        PickupType("recycle"),
+        PickupType("organics"),
+    ]
     assert next_pickup_event.area_name == "Atlantis"
 
 
@@ -108,7 +116,11 @@ async def test_get_next_pickup_event_same_day(aresponses):
         next_pickup_event = await client.async_get_next_pickup_event()
 
         assert next_pickup_event.date == date(2020, 11, 2)
-        assert next_pickup_event.pickup_types == ["garbage", "recycle", "organics"]
+        assert next_pickup_event.pickup_types == [
+            PickupType("garbage", "Trash"),
+            PickupType("recycle"),
+            PickupType("organics"),
+        ]
         assert next_pickup_event.area_name == "Atlantis"
 
 


### PR DESCRIPTION
**Describe what the PR does:**

Per https://github.com/bachya/aiorecollect/issues/6, Recollect Waste can sometimes return human-friendly names for pickup types. This PR alters the API to return `PickupType` objects, which contain both the original name _and_ the friendly name (when it exists).

**Does this fix a specific issue?**

Fixes https://github.com/bachya/aiorecollect/issues/6
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
