### PR TITLE
Update usage and ReCollect name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,4 +65,4 @@ repos:
       - id: shellcheck
         args:
           - --format=json
-        files: script/*
+        files: ^script/.+

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/65fe7eb308dca67c1038/maintainability)](https://codeclimate.com/github/bachya/aiorecollect/maintainability)
 [![Say Thanks](https://img.shields.io/badge/SayThanks-!-1EAEDB.svg)](https://saythanks.io/to/bachya)
 
-`aiorecollect` is a Python 3, asyncio-based library for the Recollect Waste API. It
+`aiorecollect` is a Python 3, asyncio-based library for the ReCollect Waste API. It
 allows users to programmatically retrieve schedules for waste removal in their area,
 including trash, recycling, compost, and more.
 
@@ -30,13 +30,15 @@ pip install aiorecollect
 
 # Place and Service IDs
 
-To use `aiorecollect`, you must know both your Recollect Place and Service IDs:
+To use `aiorecollect`, you must know both your ReCollect Place and Service IDs.
 
-1. In Google Chrome, open up the Developer console and go to the Network tab.
-2. Navigate to your city's Recollect collection calendar.
-3. Search for and select your address in the UI.
-4. Watch for a request that looks like `https://api.recollect.net/api/places/(place_id)/services/(service_id)/events...`
-5. Use the place_id and service_id when instantiating a new `Client`.
+In general, cities/municipalities that utilize ReCollect will give you a way to
+subscribe to a calendar with pickup dates. If you examine the iCal URL for this
+calendar, the Place and Service IDs are embedded in it:
+
+```
+webcal://recollect.a.ssl.fastly.net/api/places/PLACE_ID/services/SERVICE_ID/events.en-US.ics
+```
 
 # Usage
 
@@ -89,7 +91,7 @@ human-friendly representation when it exists:
 
 ## Connection Pooling
 
-By default, the library creates a new connection to Recollect with each coroutine. If
+By default, the library creates a new connection to ReCollect with each coroutine. If
 you are calling a large number of coroutines (or merely want to squeeze out every second
 of runtime savings possible), an
 [`aiohttp`](https://github.com/aio-libs/aiohttp) `ClientSession` can be used for connection

--- a/aiorecollect/client.py
+++ b/aiorecollect/client.py
@@ -1,4 +1,4 @@
-"""Define an client to interact with Recollect Waste."""
+"""Define an client to interact with ReCollect Waste."""
 from dataclasses import dataclass
 from datetime import date
 import logging

--- a/aiorecollect/errors.py
+++ b/aiorecollect/errors.py
@@ -2,7 +2,7 @@
 
 
 class RecollectError(Exception):
-    """Define a base Recollect Waste exception."""
+    """Define a base ReCollect Waste exception."""
 
     pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ use_parentheses = true
 [tool.poetry]
 name = "aiorecollect"
 version = "1.0.1"
-description = "A Python 3, asyncio-based library for the Recollect Waste API"
+description = "A Python 3, asyncio-based library for the ReCollect Waste API"
 readme = "README.md"
 authors = ["Aaron Bach <bachya1208@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
**Describe what the PR does:**

I heard from the CTO of ReCollect today:

> Hi Aaron - my name is Luke, I'm the CTO of ReCollect.  I discovered your HA work this weekend.
> 
> I wanted to suggest an easier way to find your place ID and service ID.  If you navigate to get an ical feed, you can see the Place ID and Service ID easier.
> 
> ![Screen Shot 2020-12-16 at 11 15 30 AM](https://user-images.githubusercontent.com/47216/102389274-1976f900-3f90-11eb-9737-6e62556be8f0.png)
> 
> A minor thing, but for consistency can you spell the company ReCollect with the C?
> 
> My hacker buddies running HA saw ReCollect in the release notes!

This PR addresses his two points:

1. Updates the documentation to reflect an easier method of finding Place and Service IDs
2. Updates our docs to use "ReCollect" instead of "Recollect"

Additionally, since I was in there, I made a one-line fix to a `pre-commit` hook warning.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
