### PR TITLE
Return pickup dates as datetime objects

### DIFF
--- a/aiorecollect/client.py
+++ b/aiorecollect/client.py
@@ -1,6 +1,6 @@
 """Define an client to interact with ReCollect Waste."""
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 import logging
 from typing import List, Optional
 
@@ -28,7 +28,7 @@ class PickupType:
 class PickupEvent:
     """Define a waste pickup event."""
 
-    date: date
+    date: datetime
     pickup_types: List[PickupType]
     area_name: Optional[str]
 
@@ -83,7 +83,7 @@ class Client:
         """Get the very next pickup event."""
         pickup_events = await self.async_get_pickup_events()
         for event in pickup_events:
-            if event.date >= date.today():
+            if event.date >= datetime.today():
                 return event
         raise DataError("No pickup events found after today")
 
@@ -114,7 +114,9 @@ class Client:
                 pickup_types.append(PickupType(flag["name"], flag.get("subject")))
 
             events.append(
-                PickupEvent(date.fromisoformat(event["day"]), pickup_types, area_name)
+                PickupEvent(
+                    datetime.strptime(event["day"], "%Y-%m-%d"), pickup_types, area_name
+                )
             )
 
         return events

--- a/examples/test_client.py
+++ b/examples/test_client.py
@@ -7,8 +7,8 @@ from aiorecollect.errors import RequestError
 
 _LOGGER = logging.getLogger(__name__)
 
-PLACE_ID = "<PLACE ID>"
-SERVICE_ID = "<SERVICE ID>"
+PLACE_ID = "22BC7342-745B-11E5-9A0E-78B640878761"
+SERVICE_ID = "248"
 
 
 async def main() -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,5 @@
 """Test tag API endpoints."""
-from datetime import date
+from datetime import date, datetime
 
 from aiohttp import ClientSession
 from freezegun import freeze_time
@@ -39,7 +39,7 @@ async def test_get_next_pickup_event_type1(aresponses):
         client = Client(TEST_PLACE_ID, TEST_SERVICE_ID, session=session)
         next_pickup_event = await client.async_get_next_pickup_event()
 
-        assert next_pickup_event.date == date(2020, 11, 2)
+        assert next_pickup_event.date == datetime(2020, 11, 2, 0, 0, 0)
         assert next_pickup_event.pickup_types == [
             PickupType("garbage", "Trash"),
             PickupType("recycle"),
@@ -67,7 +67,7 @@ async def test_get_next_pickup_event_type2(aresponses):
         client = Client(TEST_PLACE_ID, TEST_SERVICE_ID, session=session)
         next_pickup_event = await client.async_get_next_pickup_event()
 
-        assert next_pickup_event.date == date(2020, 12, 1)
+        assert next_pickup_event.date == datetime(2020, 12, 1, 0, 0, 0)
         assert next_pickup_event.pickup_types == [
             PickupType("Recycling", "Recycling"),
             PickupType("Organics", "Organics"),
@@ -94,7 +94,7 @@ async def test_get_next_pickup_event_oneshot(aresponses):
     client = Client(TEST_PLACE_ID, TEST_SERVICE_ID)
     next_pickup_event = await client.async_get_next_pickup_event()
 
-    assert next_pickup_event.date == date(2020, 11, 2)
+    assert next_pickup_event.date == datetime(2020, 11, 2, 0, 0, 0)
     assert next_pickup_event.pickup_types == [
         PickupType("garbage", "Trash"),
         PickupType("recycle"),
@@ -143,7 +143,7 @@ async def test_get_next_pickup_event_same_day(aresponses):
         client = Client(TEST_PLACE_ID, TEST_SERVICE_ID, session=session)
         next_pickup_event = await client.async_get_next_pickup_event()
 
-        assert next_pickup_event.date == date(2020, 11, 2)
+        assert next_pickup_event.date == datetime(2020, 11, 2, 0, 0, 0)
         assert next_pickup_event.pickup_types == [
             PickupType("garbage", "Trash"),
             PickupType("recycle"),


### PR DESCRIPTION
**Describe what the PR does:**

This PR alters `PickupEvent` objects to hold a `datetime` instead of a `date` so that localization can properly occur.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
