### PR TITLE
Don't include dates that have no pickup events

### DIFF
--- a/aiorecollect/client.py
+++ b/aiorecollect/client.py
@@ -113,7 +113,8 @@ class Client:
 
                 pickup_types.append(PickupType(flag["name"], flag.get("subject")))
 
-            # If not of our events are "pickup" events, don't bother appending:
+            # If this event doesn't include any "pickup" flags, don't both including
+            # it:
             if not pickup_types:
                 continue
 

--- a/aiorecollect/client.py
+++ b/aiorecollect/client.py
@@ -113,6 +113,10 @@ class Client:
 
                 pickup_types.append(PickupType(flag["name"], flag.get("subject")))
 
+            # If not of our events are "pickup" events, don't bother appending:
+            if not pickup_types:
+                continue
+
             events.append(
                 PickupEvent(
                     datetime.strptime(event["day"], "%Y-%m-%d"), pickup_types, area_name

--- a/aiorecollect/client.py
+++ b/aiorecollect/client.py
@@ -113,8 +113,8 @@ class Client:
 
                 pickup_types.append(PickupType(flag["name"], flag.get("subject")))
 
-            # If this event doesn't include any "pickup" flags, don't both including
-            # it:
+            # If this event doesn't include any "pickup" flags, don't bother including
+            # it (since, in that case, it really isn't an event we care about):
             if not pickup_types:
                 continue
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -170,7 +170,7 @@ async def test_get_pickup_events(aresponses):
         client = Client(TEST_PLACE_ID, TEST_SERVICE_ID, session=session)
         pickup_events = await client.async_get_pickup_events()
 
-        assert len(pickup_events) == 6
+        assert len(pickup_events) == 5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

Sometimes, the Recollect API will return events without any `pickup` flags – for example:

```json
{
    "custom_subject": "",
    "options": {},
    "custom_message": "",
    "opts": {
        "calendar_only": 1
    },
    "end_day": "2021-06-28",
    "id": 14757771,
    "day": "2021-05-28",
    "is_approved": 1,
    "zone_id": 181234,
    "flags": [
        {
            "opts": {
                "event_type": "weeklong",
                "event_proto": {
                    "calendar_only": 1
                }
            },
            "textColor": "#0B0B0B",
            "icon": "",
            "short_text_message": null,
            "voice_message": null,
            "is_week_long": 1,
            "icon_uri_fragment": null,
            "event_type": "weeklong",
            "service_name": "waste",
            "subject": "Cart Delivery",
            "id": 13736,
            "backgroundColor": "#4FE6CD",
            "area_name": "Edmonton",
            "plain_text_message": null,
            "color": "#4FE6CD",
            "html_message": "...",
            "borderColor": "#4FE6CD",
            "sort_order": 8,
            "name": "cartdelivery"
        }
    ]
}
```

Even though these events had no pickups, they were being included in the resulting output. Since the primary use of this API is to show pickup events in Home Assistant, we need to remove events that don't actually include pickups for things to work correctly. This PR makes that fix.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
