### PR TITLE
Fix bug where pickup event return datetime (instead of date)

### DIFF
--- a/aiorecollect/client.py
+++ b/aiorecollect/client.py
@@ -28,7 +28,7 @@ class PickupType:
 class PickupEvent:
     """Define a waste pickup event."""
 
-    date: datetime
+    date: date
     pickup_types: List[PickupType]
     area_name: Optional[str]
 
@@ -86,7 +86,7 @@ class Client:
         """Get the very next pickup event."""
         pickup_events = await self.async_get_pickup_events()
         for event in pickup_events:
-            if event.date >= datetime.today():
+            if event.date >= date.today():
                 return event
         raise DataError("No pickup events found after today")
 
@@ -123,7 +123,9 @@ class Client:
 
             events.append(
                 PickupEvent(
-                    datetime.strptime(event["day"], "%Y-%m-%d"), pickup_types, area_name
+                    datetime.strptime(event["day"], "%Y-%m-%d").date(),
+                    pickup_types,
+                    area_name,
                 )
             )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,5 @@
 """Test tag API endpoints."""
-from datetime import date, datetime
+from datetime import date
 
 from aiohttp import ClientSession
 from freezegun import freeze_time
@@ -39,7 +39,7 @@ async def test_get_next_pickup_event_type1(aresponses):
         client = Client(TEST_PLACE_ID, TEST_SERVICE_ID, session=session)
         next_pickup_event = await client.async_get_next_pickup_event()
 
-        assert next_pickup_event.date == datetime(2020, 11, 2, 0, 0, 0)
+        assert next_pickup_event.date == date(2020, 11, 2)
         assert next_pickup_event.pickup_types == [
             PickupType("garbage", "Trash"),
             PickupType("recycle"),
@@ -67,7 +67,7 @@ async def test_get_next_pickup_event_type2(aresponses):
         client = Client(TEST_PLACE_ID, TEST_SERVICE_ID, session=session)
         next_pickup_event = await client.async_get_next_pickup_event()
 
-        assert next_pickup_event.date == datetime(2020, 12, 1, 0, 0, 0)
+        assert next_pickup_event.date == date(2020, 12, 1)
         assert next_pickup_event.pickup_types == [
             PickupType("Recycling", "Recycling"),
             PickupType("Organics", "Organics"),
@@ -94,7 +94,7 @@ async def test_get_next_pickup_event_oneshot(aresponses):
     client = Client(TEST_PLACE_ID, TEST_SERVICE_ID)
     next_pickup_event = await client.async_get_next_pickup_event()
 
-    assert next_pickup_event.date == datetime(2020, 11, 2, 0, 0, 0)
+    assert next_pickup_event.date == date(2020, 11, 2)
     assert next_pickup_event.pickup_types == [
         PickupType("garbage", "Trash"),
         PickupType("recycle"),
@@ -143,7 +143,7 @@ async def test_get_next_pickup_event_same_day(aresponses):
         client = Client(TEST_PLACE_ID, TEST_SERVICE_ID, session=session)
         next_pickup_event = await client.async_get_next_pickup_event()
 
-        assert next_pickup_event.date == datetime(2020, 11, 2, 0, 0, 0)
+        assert next_pickup_event.date == date(2020, 11, 2)
         assert next_pickup_event.pickup_types == [
             PickupType("garbage", "Trash"),
             PickupType("recycle"),


### PR DESCRIPTION
**Describe what the PR does:**

The docs say that `PickupEvent` objects carry a `datetime.date`, but in reality, they were carrying `datetime.datetime`s. This PR fixes that.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
