### PR TITLE
Ensure "reminder only" results are hidden

### DIFF
--- a/aiorecollect/client.py
+++ b/aiorecollect/client.py
@@ -92,6 +92,11 @@ class Client:
         else:
             session = ClientSession(timeout=ClientTimeout(total=DEFAULT_TIMEOUT))
 
+        kwargs.setdefault("params", {})
+        # ReCollect includes some "reminder" events in its JSON, which often aren't
+        # related to actual pickups and can clutter the response; we hide these:
+        kwargs["params"]["hide"] = "reminder_only"
+
         try:
             async with session.request(method, url, **kwargs) as resp:
                 data = await resp.json()


### PR DESCRIPTION
**Describe what the PR does:**

According to https://github.com/home-assistant/core/issues/99480, some ReCollect calendars include "reminders" (non-pickup-related flags) that can clog up the results for some place/service ID combinations. This PR ensures that reminders are ignored in responses.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
